### PR TITLE
Added state driven draft components

### DIFF
--- a/app/(userpages)/layout.scss
+++ b/app/(userpages)/layout.scss
@@ -4,3 +4,10 @@
     flex-direction: row;
     gap:1rem;
 }
+
+.profile-page{
+    display: flex;
+    flex-direction: column;
+    align-items:center;
+    flex-grow: 1;
+}

--- a/app/(userpages)/layout.tsx
+++ b/app/(userpages)/layout.tsx
@@ -22,10 +22,10 @@ export default function ProfileBaseLayout({
             <UserProviderWrapper>
                 <>
                     <UserPageHeader />
-                    <main className='userpages-layout'>
+                    <div className='userpages-layout'>
                         <Aside />
                         {children}
-                    </main>
+                    </div>
                     <footer></footer>
                 </>
             </UserProviderWrapper>

--- a/app/(userpages)/profile/drafts/page.tsx
+++ b/app/(userpages)/profile/drafts/page.tsx
@@ -1,11 +1,12 @@
 //This is where the user can see and handle their drafts
-
+import { AddDraft } from '@/app/components/(userpages)/profile/drafts/AddDraft'
 import { UserDraftDisplay } from '@/app/components/(userpages)/profile/drafts/UserDraftDisplay'
 
 export default function DraftPage() {
     return (
-            <div id='profile-page'>
+            <div className='profile-page'>
                 <UserDraftDisplay />
+                <AddDraft/>
             </div>
     )
 }

--- a/app/(userpages)/profile/layout.tsx
+++ b/app/(userpages)/profile/layout.tsx
@@ -1,4 +1,4 @@
-//Contains common layout for userpages, including contextprovider for user-assets from DB
+//This layout provides the userId from clerc to the usercontext shared by userpages
 'use client'
 
 import { useContext, useEffect } from 'react'
@@ -15,15 +15,12 @@ export default function ProfileBaseLayout({
 
     const { userId } = useAuth()
     useEffect(() => {
-
-
         userId ? setUser(userId) : setUser(null)
     },)
 
     return (
         <>
             {children}
-
         </>
     )
 }

--- a/app/components/(userpages)/profile/drafts/AddDraft.tsx
+++ b/app/components/(userpages)/profile/drafts/AddDraft.tsx
@@ -1,0 +1,28 @@
+'use client'
+import './adddraft.scss'
+
+import { useState} from 'react'
+
+import { DbSaveWeave } from '@/app/components/draft/draftoptions/dbhandler/DbSaveWeave'
+import { SecondaryMenu } from '@/app/components/zSharedComponents/SecondaryMeny'
+
+import { EditDraftForm } from './EditDraftForm'
+
+export function AddDraft() {
+
+    const [open, setIsOpen] = useState(false);
+    const openForm = () => setIsOpen(true);
+    const closeForm = () => setIsOpen(false);
+
+    return (
+        <>
+            <div className={open ? 'new-draft-container' : 'hidden'} onMouseLeave={closeForm}>
+                <EditDraftForm open={true} resource={'none'} />
+                <SecondaryMenu>
+                    <DbSaveWeave />
+                </SecondaryMenu>
+            </div>
+            <button onClick={openForm}>Create new draft</button>
+        </>
+    )
+}

--- a/app/components/(userpages)/profile/drafts/EditDraftForm.tsx
+++ b/app/components/(userpages)/profile/drafts/EditDraftForm.tsx
@@ -4,6 +4,7 @@ import './editdraftform.scss'
 
 import { ColorPicker } from '@/app/components/draft/colorpicker/Colorpicker'
 import { Draft } from '@/app/components/draft/draft/Draft'
+import { StateDraft } from '@/app/components/draft/draft/StateDraft'
 
 export function EditDraftForm(params: { resource: any, open: boolean }) {
 
@@ -12,6 +13,7 @@ export function EditDraftForm(params: { resource: any, open: boolean }) {
             <div className='edit-draft'>
                 <ColorPicker />
                 <Draft />
+               <StateDraft weaveObj={{...params.resource.weave}}/>
             </div >
         </div>
     )

--- a/app/components/(userpages)/profile/drafts/EditDraftForm.tsx
+++ b/app/components/(userpages)/profile/drafts/EditDraftForm.tsx
@@ -7,11 +7,10 @@ import { Draft } from '@/app/components/draft/draft/Draft'
 import { StateDraft } from '@/app/components/draft/draft/StateDraft'
 
 export function EditDraftForm(params: { resource: any, open: boolean }) {
-
+//TODO:Move colorpixker style to relevant place
     return (
         <div className={params.open ? 'edit-draft-container' : 'hidden'}>
             <div className='edit-draft'>
-                <ColorPicker />
                 <StateDraft weaveObj={{ ...params.resource.weave }} />
             </div >
         </div>

--- a/app/components/(userpages)/profile/drafts/EditDraftForm.tsx
+++ b/app/components/(userpages)/profile/drafts/EditDraftForm.tsx
@@ -12,8 +12,7 @@ export function EditDraftForm(params: { resource: any, open: boolean }) {
         <div className={params.open ? 'edit-draft-container' : 'hidden'}>
             <div className='edit-draft'>
                 <ColorPicker />
-                <Draft />
-               <StateDraft weaveObj={{...params.resource.weave}}/>
+                <StateDraft weaveObj={{ ...params.resource.weave }} />
             </div >
         </div>
     )

--- a/app/components/(userpages)/profile/drafts/UserDraftDisplay.tsx
+++ b/app/components/(userpages)/profile/drafts/UserDraftDisplay.tsx
@@ -1,23 +1,16 @@
+//This component is a container for draftcards and represents the main content of the profile/drafts
 'use client'
 import './userdraftdisplay.scss'
 
-import { useContext,useState } from 'react'
-
 import { DraftCard } from '@/app/components/(userpages)/profile/drafts/DraftCard'
-import { UserContext } from '@/app/resources/contexts/usercontext'
-import { UserContextType } from '@/app/resources/types/contexts'
-import { DraftList } from '@/app/resources/types/dbdocuments'
+import { useUserContext } from '@/app/resources/contexts/usercontext'
 
 export function UserDraftDisplay() {
 
-    const [userDrafts, setUserDrafts] = useState<DraftList>([])
-
-    //TODO: extract relevant from context in separate step
-    const { drafts } = useContext(UserContext) as UserContextType
+    const { drafts } = useUserContext()
 
     return (
         <>
-
             {drafts ? 
             <div className='userdrafts'>
                 {drafts.map(draft => {
@@ -25,17 +18,14 @@ export function UserDraftDisplay() {
                     else {
                         return (<DraftCard key={draft._id} draft={draft} />)
                     }
-
                 })}
             </div> : <div>Loading drafts</div>}
 
             
             {drafts && drafts.length==0 ? 
-            <div className='userdrafts'>
-             Card to create a draft
+            <div >
+             You have no drafts to show.
             </div> : null}
-
-
         </>
     )
 }

--- a/app/components/(userpages)/profile/drafts/adddraft.scss
+++ b/app/components/(userpages)/profile/drafts/adddraft.scss
@@ -1,0 +1,21 @@
+@use '@/app/resources/style/variables.scss' as v;
+@use '@/app/resources/style/mixins.scss' as m;
+
+.new-draft-container{
+    @include m.flexColumn;
+    @include m.rounded-corners;
+    border: v.$thick-border;
+    background-color: aqua;
+    position: absolute;
+    top: 0px;
+    align-self: center;
+    margin-top:3rem;
+    margin-left:5rem;
+    margin-right:5rem;
+   
+    display: flex;
+    flex-direction: column;
+    gap:1rem;
+    padding:1rem;
+    
+}

--- a/app/components/(userpages)/profile/drafts/editdraftform.scss
+++ b/app/components/(userpages)/profile/drafts/editdraftform.scss
@@ -6,7 +6,7 @@
     .edit-draft {
 
         .draft {
-            padding: 1rem 0 0 0;
+            padding: 0 0 0 0;
         }
 
         padding: 1rem 1rem 0 1rem;

--- a/app/components/draft/colorpicker/Colorpicker_contained.tsx
+++ b/app/components/draft/colorpicker/Colorpicker_contained.tsx
@@ -1,0 +1,105 @@
+//The colorpick form displays wich color is currently picked for clicking in the draft but also displays wich colors are present in warp/weft.
+//Previous colors can be picked again by click and replaced in the draft by changeing
+import './colorpicker_contained.scss'
+
+import { SetStateAction,useContext, useEffect, useState } from 'react'
+
+import { Colorinput } from '@/app/components/zSharedComponents/Colorinput'
+import { WeaveContext } from '@/app/resources/contexts/weavecontext'
+import { WeaveContextType } from '@/app/resources/types/contexts'
+
+import { replaceColorInGrid } from '../weaveGridHandler/replaceColorInGrid'
+import { PreviousColor } from './Previouscolor'
+export function ColorPicker_contained(props: { warpGrid: grid, updateWarpGrid:(value: SetStateAction<grid>) => void , treadleGrid: grid, updateTreadleGrid:(value: SetStateAction<grid>) => void }) {
+
+    //TODO: Update styling of duplicated components before removal of the old ones
+    const { warpGrid, treadleGrid, updateTreadleGrid, updateWarpGrid } = props
+
+    const [warpColors, setWarpColors] = useState<colorCollection>([])
+    const [weftColors, setWeftColors] = useState<colorCollection>([])
+
+    const { currentColor, setCurrentColor, colorChange } = useContext(WeaveContext) as WeaveContextType
+
+    //Keeps the state for warpcolors on updated
+    useEffect(() => {
+        if (!warpGrid) {
+            setWarpColors([])
+            return
+        }
+        let uniqueColors: color[] = []
+        warpGrid.forEach(row => {
+            let colors = row.filter((color) => color != '' && !uniqueColors.includes(color))
+            uniqueColors = uniqueColors.concat(colors)
+        })
+        setWarpColors(Array.from(new Set(uniqueColors)))
+    }, [warpGrid])
+
+    //Keeps the state for weftcolors on updated
+    useEffect(() => {
+        if (!treadleGrid) {
+            setWeftColors([])
+            return
+        }
+        let uniqueColors: color[] = []
+        treadleGrid.forEach(row => {
+            let colors = row.filter((color) => color != '' && !uniqueColors.includes(color))
+            uniqueColors = uniqueColors.concat(colors)
+        })
+        setWeftColors(Array.from(new Set(uniqueColors)))
+    }, [treadleGrid])
+
+    //Sets the active color
+    function updateCurrentColor(e: React.ChangeEvent<HTMLInputElement> | React.MouseEvent<HTMLInputElement>): void {
+        let target = e.target as HTMLInputElement
+        const value = target.value
+        setCurrentColor(value)
+    }
+
+    //Replaces all instances of a color in the warp with a new value
+    function updateWarpColor(e: React.ChangeEvent<HTMLInputElement>): void {
+        let target = e.target as HTMLInputElement
+        const color = target.value
+        const colorInputId = target.id
+        const [gridName, previousColor] = colorInputId.split('-') as [gridName, color]
+        updateWarpGrid( prevValue=>replaceColorInGrid(prevValue, previousColor, color))
+    }
+    //Replaces all instances of a color in the weft with a new value
+    function updateWeftColor(e: React.ChangeEvent<HTMLInputElement>): void {
+        let target = e.target as HTMLInputElement
+        const color = target.value
+        const colorInputId = target.id
+        const [gridName, previousColor] = colorInputId.split('-') as [gridName, color]
+        updateTreadleGrid( prevValue=>replaceColorInGrid(prevValue, previousColor, color))
+    }
+
+    return (
+        <div className='form-container'>
+            <form className='colorpick-form' >
+                <div>
+                    <p>
+                        Pick a color and click <br />
+                        to add warp/weft/ tie up.
+                    </p>
+                </div>
+                <div>
+                    <div className='color-container'>
+                        <div className="color-box">
+                            <h3>Current <br />color</h3>
+                            <Colorinput id="current-color" label="" value={currentColor} changehandler={updateCurrentColor} clickhandler={undefined} />
+                        </div>
+
+                        <div className="color-box" >
+                            <h3>Colors in <br />draft</h3>
+                            <div className="previous-colors">
+                                {(warpColors.length > 0) && (
+                                    <PreviousColor header='Warp' clickhandler={updateCurrentColor} changehandler={updateWarpColor} content={warpColors} />)}
+                                {(weftColors.length > 0) && (
+                                    <PreviousColor header='Weft' clickhandler={updateCurrentColor} changehandler={updateWeftColor} content={weftColors} />)}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </form>
+        </div >
+    )
+}

--- a/app/components/draft/colorpicker/colorpicker_contained.scss
+++ b/app/components/draft/colorpicker/colorpicker_contained.scss
@@ -1,0 +1,64 @@
+@use '@/app/resources/style/mixins.scss' as m;
+@use '@/app/resources/style/variables.scss' as v;
+
+.edit-draft {
+
+    .form-container {
+
+        display: flex;
+        flex-direction: column;
+        width: 100%;
+
+        label {
+            font-size: 0.8rem;
+        }
+
+        h3 {
+            margin: 0 0 0.3rem 0;
+            padding: 0;
+        }
+
+        .colorpick-form {
+            @include m.rounded-corners;
+            border: v.$thick-border;
+            @include m.text-area;
+            padding: 1rem;
+            display: flex;
+            flex-direction: row;
+            flex-wrap: nowrap;
+            gap: 1rem;
+            align-items: center;
+            margin: 0px;
+            width: 100%;
+
+            .color-container {
+                display: flex;
+                flex-direction: row;
+                justify-items: center;
+                gap: 1rem;
+
+                .color-box {
+                    box-sizing: border-box;
+
+                    input#current-color {
+                        &[type=color] {
+                            width: 2.6rem;
+                            height: 2rem;
+                            padding: 0;
+                            border: 0;
+                            margin: -0.3rem;
+                            box-sizing: border-box;
+                            background-color: inherit;
+                        }
+                    }
+
+                    .previous-colors {
+                        display: flex;
+                        justify-content: center;
+                        gap: 0.5rem;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/components/draft/draft/Grid_contained.tsx
+++ b/app/components/draft/draft/Grid_contained.tsx
@@ -1,0 +1,46 @@
+'use-client'
+//Component creates rows for each item in an array and supplies the item as contents to the row.
+//The prop type is used to keep track of the parentgrid of downstream components
+import './grid.scss';
+
+import { ReactElement, SetStateAction, useContext } from 'react'
+
+import { Row } from '@/app/components/draft/draft/Row'
+import { WeaveContext } from '@/app/resources/contexts/weavecontext'
+import { WeaveContextType } from '@/app/resources/types/contexts'
+
+import { updateGrid } from '../weaveGridHandler/updateGrid';
+import { CellProps } from './Cell'
+
+interface CellTarget extends EventTarget {
+    id: string
+}
+
+interface Grid extends HTMLDivElement {
+    type: string,
+    props: object,
+    key: any
+}
+export function Grid_contained(props: { content: grid, type: string, setContent: ((value: SetStateAction<grid>) => void) | null }): ReactElement<Grid> {
+
+    const { currentColor } = useContext(WeaveContext) as WeaveContextType
+
+    //On click, update backgroundcolor
+    function clickhandlerWrapper(e: React.MouseEvent<CellProps>) {
+
+        if (!setContent) {
+            return
+        }
+        const cell = e.target as CellTarget
+        setContent(prevValue => updateGrid(prevValue, cell.id, currentColor))
+    }
+
+    const { type, setContent, content } = props
+
+    const gridRows = content.map((item, index) => {
+        //TODO: Handle empty item.
+        return <Row content={item} key={`${type}-row-${index}`} rownr={index} type={type} />
+    })
+
+    return <div className="grid" id={`${type}-wrapper`} onClick={(e) => { setContent != null && clickhandlerWrapper(e as React.MouseEvent<Grid>) }}>{gridRows}</div>
+}

--- a/app/components/draft/draft/StateDraft.tsx
+++ b/app/components/draft/draft/StateDraft.tsx
@@ -11,9 +11,6 @@ import { Weave } from './Weave'
 
 export function StateDraft(props: { weaveObj: WeaveObject}){
 
-    console.log(props.weaveObj.shafts)
-    console.log(props.weaveObj)
-
     const[treadleGrid, setTreadleGrid]=useState<grid>([['']])
     const [ tieUpGrid, setTieUpGrid]=useState<grid>([['']])
     const [warpGrid, setWarpGrid]=useState<grid>([['']])

--- a/app/components/draft/draft/StateDraft.tsx
+++ b/app/components/draft/draft/StateDraft.tsx
@@ -3,37 +3,46 @@ import './draft.scss'
 import { useEffect, useState } from 'react'
 
 import { Grid } from '@/app/components/draft/draft/Grid'
+import { createWeave } from '@/app/components/draft/weaveObjHandler/set/writeDraftGrid'
 import { Errormsg } from '@/app/components/zSharedComponents/Errormsg'
 
 import { readWeaveObject } from '../weaveObjHandler/set/readWeaveObject'
-import { Weave } from './Weave'
 
 
-export function StateDraft(props: { weaveObj: WeaveObject}){
+export function StateDraft(props: { weaveObj: WeaveObject }) {
 
-    const[treadleGrid, setTreadleGrid]=useState<grid>([['']])
-    const [ tieUpGrid, setTieUpGrid]=useState<grid>([['']])
-    const [warpGrid, setWarpGrid]=useState<grid>([['']])
+    const [treadleGrid, setTreadleGrid] = useState<grid>([['']])
+    const [tieUpGrid, setTieUpGrid] = useState<grid>([['']])
+    const [warpGrid, setWarpGrid] = useState<grid>([['']])
+    const [weaveGrid, setWeaveGrid] = useState<grid>([['']])
 
-  useEffect(()=>{
-    if(Object.keys(props.weaveObj).length > 0){
-    const grids= readWeaveObject({...props.weaveObj})
-    setTieUpGrid(grids.tieupGrid)
-    setWarpGrid(grids.warpGrid)
-    setTreadleGrid(grids.treadleGrid)
-    }
-  },[props.weaveObj])
+    useEffect(() => {
+        if (Object.keys(props.weaveObj).length > 0) {
+            const grids = readWeaveObject({ ...props.weaveObj })
+            setTieUpGrid(grids.tieUpGrid)
+            setWarpGrid(grids.warpGrid)
+            setTreadleGrid(grids.treadleGrid)
 
+
+        }
+    }, [props.weaveObj])
+
+    useEffect(() => {
+
+        const weave = createWeave({ warpGrid, tieUpGrid, treadleGrid }, treadleGrid.length, warpGrid[0].length)
+        setWeaveGrid(weave)
+
+    }, [treadleGrid, tieUpGrid, warpGrid])
 
 
     return (
         (treadleGrid && tieUpGrid && warpGrid) ? (
             <div className="draft">
                 <div className="partial">
-                    <Weave /> <Grid content={treadleGrid} type='treadle' />
+                    <Grid content={weaveGrid} type='weave' /> <Grid content={treadleGrid} type='treadle' />
                 </div>
                 <div className="partial">
-                    <Grid content={warpGrid} type='warp'  /> <Grid content={tieUpGrid} type='tieup'/>
+                    <Grid content={warpGrid} type='warp' /> <Grid content={tieUpGrid} type='tieup' />
                 </div>
             </div>) : (<Errormsg text='Ooops something went wrong when creating the draft, please try again' />)
     )

--- a/app/components/draft/draft/StateDraft.tsx
+++ b/app/components/draft/draft/StateDraft.tsx
@@ -2,12 +2,12 @@ import './draft.scss'
 
 import { useEffect, useState } from 'react'
 
-import { Grid } from '@/app/components/draft/draft/Grid'
+import { Grid_contained } from '@/app/components/draft/draft/Grid_contained'
 import { createWeave } from '@/app/components/draft/weaveObjHandler/set/writeDraftGrid'
 import { Errormsg } from '@/app/components/zSharedComponents/Errormsg'
 
+import { ColorPicker_contained } from '../colorpicker/Colorpicker_contained'
 import { readWeaveObject } from '../weaveObjHandler/set/readWeaveObject'
-
 
 export function StateDraft(props: { weaveObj: WeaveObject }) {
 
@@ -16,33 +16,32 @@ export function StateDraft(props: { weaveObj: WeaveObject }) {
     const [warpGrid, setWarpGrid] = useState<grid>([['']])
     const [weaveGrid, setWeaveGrid] = useState<grid>([['']])
 
+
     useEffect(() => {
         if (Object.keys(props.weaveObj).length > 0) {
             const grids = readWeaveObject({ ...props.weaveObj })
             setTieUpGrid(grids.tieUpGrid)
             setWarpGrid(grids.warpGrid)
             setTreadleGrid(grids.treadleGrid)
-
-
         }
     }, [props.weaveObj])
 
     useEffect(() => {
 
-        const weave = createWeave({ warpGrid, tieUpGrid, treadleGrid }, treadleGrid.length, warpGrid[0].length)
-        setWeaveGrid(weave)
+        setWeaveGrid(createWeave({ warpGrid, tieUpGrid, treadleGrid }, treadleGrid.length, warpGrid[0].length))
 
     }, [treadleGrid, tieUpGrid, warpGrid])
 
 
     return (
         (treadleGrid && tieUpGrid && warpGrid) ? (
-            <div className="draft">
+            <div className="draft" >
+                <ColorPicker_contained warpGrid={warpGrid} updateWarpGrid={setWarpGrid} treadleGrid={treadleGrid} updateTreadleGrid={setTreadleGrid}/>
                 <div className="partial">
-                    <Grid content={weaveGrid} type='weave' /> <Grid content={treadleGrid} type='treadle' />
+                    <Grid_contained content={weaveGrid} type='weave' setContent={null}/> <Grid_contained content={treadleGrid} type='treadle' setContent={setTreadleGrid}/>
                 </div>
                 <div className="partial">
-                    <Grid content={warpGrid} type='warp' /> <Grid content={tieUpGrid} type='tieup' />
+                    <Grid_contained content={warpGrid} type='warp' setContent={setWarpGrid} /> <Grid_contained content={tieUpGrid} type='tieup' setContent={setTieUpGrid}/>
                 </div>
             </div>) : (<Errormsg text='Ooops something went wrong when creating the draft, please try again' />)
     )

--- a/app/components/draft/draft/StateDraft.tsx
+++ b/app/components/draft/draft/StateDraft.tsx
@@ -1,0 +1,44 @@
+import './draft.scss'
+
+import { useEffect, useState } from 'react'
+
+import { Grid } from '@/app/components/draft/draft/Grid'
+import { Errormsg } from '@/app/components/zSharedComponents/Errormsg'
+
+import { readWeaveObject } from '../weaveObjHandler/set/readWeaveObject'
+import { Weave } from './Weave'
+
+
+export function StateDraft(props: { weaveObj: WeaveObject}){
+
+    console.log(props.weaveObj.shafts)
+    console.log(props.weaveObj)
+
+    const[treadleGrid, setTreadleGrid]=useState<grid>([['']])
+    const [ tieUpGrid, setTieUpGrid]=useState<grid>([['']])
+    const [warpGrid, setWarpGrid]=useState<grid>([['']])
+
+  useEffect(()=>{
+    if(Object.keys(props.weaveObj).length > 0){
+    const grids= readWeaveObject({...props.weaveObj})
+    setTieUpGrid(grids.tieupGrid)
+    setWarpGrid(grids.warpGrid)
+    setTreadleGrid(grids.treadleGrid)
+    }
+  },[props.weaveObj])
+
+
+
+    return (
+        (treadleGrid && tieUpGrid && warpGrid) ? (
+            <div className="draft">
+                <div className="partial">
+                    <Weave /> <Grid content={treadleGrid} type='treadle' />
+                </div>
+                <div className="partial">
+                    <Grid content={warpGrid} type='warp'  /> <Grid content={tieUpGrid} type='tieup'/>
+                </div>
+            </div>) : (<Errormsg text='Ooops something went wrong when creating the draft, please try again' />)
+    )
+
+}

--- a/app/components/draft/draftoptions/dbhandler/DraftPreview.tsx
+++ b/app/components/draft/draftoptions/dbhandler/DraftPreview.tsx
@@ -21,7 +21,7 @@ export function DraftPreview(params: { weaveObj: WeaveObject }) {
     //Trim since preview cant contain the full width
     let shortTreadleGrid = newGrids.treadleGrid.slice(-11, -1)
     let shortWarpGrid = newGrids.warpGrid.map(row => { return row.slice(-11, -1) })
-    let tieUpGrid = newGrids.tieupGrid
+    let tieUpGrid = newGrids.tieUpGrid
 
     //Returns the color if present for the beat
     function getWeftColor(y: number) {

--- a/app/components/draft/draftoptions/filehandler/Uploadweave.tsx
+++ b/app/components/draft/draftoptions/filehandler/Uploadweave.tsx
@@ -24,7 +24,7 @@ export function Uploadweave() {
                         const obj: WeaveObject = JSON.parse(fileContents);
                         let newGrids = readWeaveObject(obj)
 
-                        updateGrid('tieup', newGrids.tieupGrid)
+                        updateGrid('tieup', newGrids.tieUpGrid)
                         updateGrid('warp', newGrids.warpGrid)
                         updateGrid('weft', newGrids.treadleGrid)
                     } catch (error) {

--- a/app/components/draft/weaveGridHandler/replaceColorInGrid.ts
+++ b/app/components/draft/weaveGridHandler/replaceColorInGrid.ts
@@ -1,0 +1,12 @@
+export function replaceColorInGrid(grid:grid, previousColor:color, newColor:color){
+
+    const gridCopy:grid=JSON.parse(JSON.stringify(grid))
+
+    let reColoredGrid = gridCopy.map((row, index) => {
+      const newRow = row.map(color => {
+        return color == previousColor ? newColor : color
+      })
+      return newRow
+    })
+    return reColoredGrid
+}

--- a/app/components/draft/weaveGridHandler/updateGrid.ts
+++ b/app/components/draft/weaveGridHandler/updateGrid.ts
@@ -1,0 +1,42 @@
+
+export function updateGrid(grid:grid, cellId: string, color: color)/* : (grid: grid, cellId: string, color: color) => (grid) */{
+
+    const gridCopy = JSON.parse(JSON.stringify(grid))
+    const [gridType, x, y] = cellId.split('-') as [gridName, number, number]
+
+    if (gridType == undefined || x == undefined || y == undefined ) {
+        return gridCopy
+    }
+
+    console.log(gridCopy[y][x])
+    let newColor = color
+    //Tieup allways has black fill
+    if (gridType == 'tieup') {
+        newColor = '#000000'
+    } 
+    //If warp, clear other cells in column.
+    if (gridType == 'warp') {
+        const shafts = gridCopy.length
+        for (let i = 0; i < shafts; i++) {
+            if (i != y) {
+                gridCopy[i][x] = ''
+            }
+        }
+    }
+    //If weft, clear other cells in row.
+    if (gridType == 'treadle') {
+        const treadles = gridCopy[0].length
+        for (let i = 0; i < treadles; i++) {
+            if (i != x) {
+                gridCopy[y][i] = ''
+            }
+        }
+    }
+
+    //Toggle the color of the cell
+    gridCopy[y][x]=gridCopy[y][x] == '' ? newColor : ''
+
+    //return the updated grid
+    return gridCopy
+
+}

--- a/app/components/draft/weaveObjHandler/set/readWeaveObject.ts
+++ b/app/components/draft/weaveObjHandler/set/readWeaveObject.ts
@@ -1,5 +1,4 @@
 import { defaultDraftHeight, defaultDraftWidth, defaultShafts, defaultTreadles } from '@/app/resources/constants/weaveDefaults'
-import { resizeGrid } from '@/app/resources/functions/resizeGrid'
 
 import { createGrid } from '../utils'
 import { readTieup } from './readTieup'
@@ -12,12 +11,12 @@ export function readWeaveObject(weaveObject: WeaveObject) {
     let width = Math.max(weaveObject.shafts.pattern.length, defaultDraftWidth)
     let height = Math.max(weaveObject.treadling.pattern.length, defaultDraftHeight)
 
-    let tieupGrid: grid = createGrid(treadles, shafts)
-    tieupGrid = readTieup(tieupGrid, weaveObject.tieup)
+    let tieUpGrid: grid = createGrid(treadles, shafts)
+    tieUpGrid = readTieup(tieUpGrid, weaveObject.tieup)
     let treadleGrid: grid = readWeft(weaveObject.treadling, height)
     let warpGrid: grid = readWarp(weaveObject.shafts, width)
 
 
-    return { warpGrid, tieupGrid, treadleGrid }
+    return { warpGrid, tieUpGrid, treadleGrid }
 
 }

--- a/app/components/draft/weaveObjHandler/set/readWeft.ts
+++ b/app/components/draft/weaveObjHandler/set/readWeft.ts
@@ -8,12 +8,14 @@ export function readWeft(weft: TreadlingDescription, height: number) {
     let width = weft.count || defaultTreadles
     let weftGrid: grid = createGrid(width, height)
 
+    //If grid has not been filled in, return an empty grid of correct size
     if (weft.pattern == null || !(weft.pattern.length > 0)) {
         return weftGrid
     }
 
     let colors = weft.colors
-
+    
+    //Fill the grid
     weft.pattern.forEach((treadle, index) => {
         let currentColor = defaultWeftColor
         if (colors) {

--- a/app/components/draft/weaveObjHandler/set/writeDraftGrid.ts
+++ b/app/components/draft/weaveObjHandler/set/writeDraftGrid.ts
@@ -1,0 +1,99 @@
+
+//This file exports the function to create a weaveGrid from a gridSet. It also contains the required helperfunctions.
+//Returns the color if present for the beat
+
+import { createGrid } from '../utils'
+
+//Returns the color of a specified beat
+function getWeftColor(y: number, treadleGrid: grid) {
+    if (!treadleGrid[y]) {
+        return undefined
+    }
+    let color = treadleGrid[y].find(isColored)
+    return color
+}
+
+//Returns the color of the warp for a specified thread
+function getWarpColor(x: number, warpGrid: grid) {
+
+    let warpColumn = []
+    for (let i = 0; i < warpGrid.length; i++) {
+
+        warpColumn.push(warpGrid[i][x])
+    }
+    let warpColor = warpColumn.find(isColored)
+
+    return warpColor
+}
+
+//Returns positive integer corresponding to the index of warped shaft or -1
+function getWarpedShaft(x: number, warpGrid: grid) {
+    const shafts = warpGrid.length
+
+    for (let i = 0; i <= shafts; i++) {
+        if (warpGrid[i][x] != '') {
+            return i
+        }
+    }
+    return -1
+}
+
+//Returns true if shaft and treadle are connected
+function isTiedUp(shaft: number, treadle: number, tieUpGrid: grid) {
+    if (!tieUpGrid) return
+    return tieUpGrid[shaft][treadle] != ''
+}
+
+//Returns true if the grid position is colored
+function isColored(gridItem: color) {
+    return gridItem !== '';
+}
+
+//Creates a grid and uppdates it's color in accordance with a gridSet.
+export function createWeave(grids: GridSet, draftHeight: number, draftWidth: number): grid {
+
+    const { treadleGrid, warpGrid, tieUpGrid } = grids
+
+    //Create empty grid
+    let grid = createGrid(draftWidth, draftHeight)
+    console.log(grid[0] == grid[1])
+
+    grid.forEach((row: color[], y: number) => {
+        console.log('initial draftrow')
+        console.log(row)
+        let weftColor = getWeftColor(y, treadleGrid)
+
+
+        row.forEach((cell: color, x: number) => {
+
+            let warpColor = getWarpColor(x, warpGrid)
+
+            if (weftColor == undefined) {
+
+                //Set each cell with warpcolor to warpcolor, no color if no warp
+                warpColor != undefined ? grid[y][x] = warpColor : grid[y][x] = ''
+
+            } else {
+                //console.log('there was a weft')
+                // console.log('weftcolor ' + weftColor + ', for row ' + y)
+                if (warpColor) {
+
+                    let treadleNr = treadleGrid ? treadleGrid[y].indexOf(weftColor) : undefined
+                    let shaftNr = getWarpedShaft(x, warpGrid)
+
+                    //Check tie-up on pos y/x if colored set weft otherwise warp
+                    if (shaftNr != undefined && treadleNr != undefined) {
+                        (isTiedUp(shaftNr, treadleNr, tieUpGrid)) ? grid[y][x] = weftColor : grid[y][x] = warpColor
+                    }
+                } else {
+                    //No warp but weftcolor displays weft
+                    grid[y][x] = weftColor
+                }
+            }
+        })
+        console.log('final draftrow')
+        console.log(row)
+    })
+    return grid
+
+}

--- a/app/components/draft/weaveObjHandler/set/writeDraftGrid.ts
+++ b/app/components/draft/weaveObjHandler/set/writeDraftGrid.ts
@@ -56,11 +56,9 @@ export function createWeave(grids: GridSet, draftHeight: number, draftWidth: num
 
     //Create empty grid
     let grid = createGrid(draftWidth, draftHeight)
-    console.log(grid[0] == grid[1])
 
     grid.forEach((row: color[], y: number) => {
-        console.log('initial draftrow')
-        console.log(row)
+
         let weftColor = getWeftColor(y, treadleGrid)
 
 
@@ -91,8 +89,6 @@ export function createWeave(grids: GridSet, draftHeight: number, draftWidth: num
                 }
             }
         })
-        console.log('final draftrow')
-        console.log(row)
     })
     return grid
 

--- a/app/resources/contexts/usercontext.tsx
+++ b/app/resources/contexts/usercontext.tsx
@@ -1,6 +1,6 @@
 //Context handling information and calculations between different parts (aka treadles, shafts, tieups) of the draft and calculates the weave.
 //dependencies
-import { createContext, useEffect, useState } from 'react'
+import { createContext, useContext, useEffect, useState } from 'react'
 
 import { UserContextType } from '@/app/resources/types/contexts'
 
@@ -56,3 +56,13 @@ export function UserProvider({ children }: { children: React.ReactElement | Reac
     )
 }
 
+
+export function useUserContext(){
+    const context = useContext(UserContext);
+   
+    if (!context) {
+      throw new Error('Usercontext must be used inside the userpages');
+    }
+   
+    return context;
+  };

--- a/app/resources/contexts/weavecontext.tsx
+++ b/app/resources/contexts/weavecontext.tsx
@@ -119,7 +119,7 @@ export function WeaveProvider({ children }: { children: React.ReactElement | Rea
 
     let newGrids = readWeaveObject(weaveObj)
 
-    updateGrid('tieup', newGrids.tieupGrid)
+    updateGrid('tieup', newGrids.tieUpGrid)
     updateGrid('warp', newGrids.warpGrid)
     updateGrid('weft', newGrids.treadleGrid)
   }

--- a/app/resources/types/warp.ts
+++ b/app/resources/types/warp.ts
@@ -19,3 +19,10 @@ type WarpLengthData={
 type grid=color[][]
 type gridName='weave' | 'tieup'|'warp'|'treadle'|'weft'
 
+type GridSet={
+    warpGrid:grid, 
+    tieUpGrid:grid, 
+    treadleGrid:grid,
+    weave?:grid
+}
+

--- a/app/weaver/layout.tsx
+++ b/app/weaver/layout.tsx
@@ -7,7 +7,7 @@ export default function WeaverBaseLayout({
 }) {
     return (
         <>
-            <main>  {children}</main>
+            {children}
             <footer></footer>
         </>
 


### PR DESCRIPTION
When in user pages, there is need for more than one instance of an active draft and the components affected need to contain the state for each draft, this will eventually replace the weave context but this change has not yet been implemented. context.