### PR TITLE
Add use drafts button in userpages

### DIFF
--- a/app/components/(userpages)/profile/drafts/DraftCard.tsx
+++ b/app/components/(userpages)/profile/drafts/DraftCard.tsx
@@ -6,6 +6,7 @@ import { useEffect, useRef, useState } from 'react'
 
 import { DisplayCard } from '@/app/components/(userpages)/DisplayCard'
 import { DraftPreview } from '@/app/components/draft/draftoptions/dbhandler/DraftPreview'
+import { ReplaceDraftButton } from '@/app/components/library/replaceDraftButton'
 
 import { EditDraftForm } from './EditDraftForm'
 //TODO:Add typing
@@ -43,7 +44,7 @@ export function DraftCard(params: { draft: Draft }) {
                             <p>  Shafts:<span>{draft.weave.shafts?.count || '-'}</span></p>
                             <p className='date'>  {draft.updateDate}</p>
                             <div className='action-container'>
-                                {open ? <><button type='button' onClick={closeForm}>Close</button></> : <button type='button' onClick={openForm}>Edit</button>}
+                                {open ? <><button type='button' onClick={closeForm}>Close</button></> : <><ReplaceDraftButton weave={draft.weave}/><button type='button' onClick={openForm}>Edit</button></>}
                             </div>
                         </div>
                     </div>

--- a/app/components/(userpages)/profile/drafts/EditDraftForm.tsx
+++ b/app/components/(userpages)/profile/drafts/EditDraftForm.tsx
@@ -5,6 +5,7 @@ import './editdraftform.scss'
 import { useState } from 'react'
 
 import { StateDraft } from '@/app/components/draft/draft/StateDraft'
+import { ReplaceDraftButton } from '@/app/components/library/replaceDraftButton'
 import { useUserContext } from '@/app/resources/contexts/usercontext'
 
 export function EditDraftForm(params: { resource: Draft, open: boolean, closeForm: () => void }) {
@@ -70,7 +71,7 @@ export function EditDraftForm(params: { resource: Draft, open: boolean, closeFor
                 <StateDraft weaveObj={{ ...params.resource.weave }} updateObj={updateObj} />
             </div >
             <div className='action-container'>
-                <><button type='button' onClick={(e) => { editDraft(e) }}>Save</button> <button className='icon-button' id={`draft-${draftId}`} onClick={(e) => { deleteDraft(e) }}>Delete</button></>
+                <><button type='button' onClick={(e) => { editDraft(e) }}>Save</button> <button className='icon-button' id={`draft-${draftId}`} onClick={(e) => { deleteDraft(e) }}>Delete</button><ReplaceDraftButton weave={resource.weave}/></>
             </div>
         </div>
     )

--- a/app/components/library/publicDraftCard.tsx
+++ b/app/components/library/publicDraftCard.tsx
@@ -1,6 +1,3 @@
-'use client'
-
-import { useRouter } from 'next/navigation'
 
 import { DisplayCard } from '@/app/components/(userpages)/DisplayCard'
 import { useWeaveContext } from '@/app/resources/contexts/weavecontext'
@@ -8,7 +5,7 @@ import { readWeaveObject } from '@/app/resources/functions/weaveObjHandling/read
 import { createWeave } from '@/app/resources/functions/weaveObjHandling/readWeaveObj/writeDraftGrid'
 
 import { PreviewGrid } from '../zSharedComponents/PreviewGrid'
-
+import { ReplaceDraftButton } from './replaceDraftButton'
 
 export function PublicDraftCard(params: { draft: { weave: WeaveObject } }) {
 
@@ -17,17 +14,6 @@ export function PublicDraftCard(params: { draft: { weave: WeaveObject } }) {
     const weaveGrid=createWeave(gridSet, 50,30)
     const { upSetGrids } = useWeaveContext()
 
-    const router = useRouter()
-
-    function useDraft() {
-        if (weave) {
-            upSetGrids(weave)
-            router.push('/weaver/draft')
-        } else {
-            alert('Ops, something went wrong, please try another one')
-        }
-    }
-
     return (
         <div id='draft-card-container'>
             <DisplayCard >
@@ -35,7 +21,7 @@ export function PublicDraftCard(params: { draft: { weave: WeaveObject } }) {
                     <div className='vertical draft-card' >
                         
                         <div className='draft-info-container'>
-                                <button type='button' onClick={useDraft}>Use</button>
+                            <ReplaceDraftButton weave={weave}/>
                         </div>
                         <PreviewGrid content={weaveGrid} type='publicDraft' />
 

--- a/app/components/library/replaceDraftButton.tsx
+++ b/app/components/library/replaceDraftButton.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+
+import { useWeaveContext } from '@/app/resources/contexts/weavecontext'
+
+export function ReplaceDraftButton(params:  { weave: WeaveObject } ){
+    const { weave } = params
+    const { upSetGrids } = useWeaveContext()
+
+    const router = useRouter()
+
+    function useDraft() {
+        if (weave) {
+            upSetGrids(weave)
+            router.push('/weaver/draft')
+        } else {
+            alert('Ops, something went wrong, please try another one')
+        }
+    }
+
+    return(
+        <button type='button' onClick={useDraft}>Use</button>
+    )
+
+}


### PR DESCRIPTION
In order to reuse the button implemented in the library for developing a draft code was refactored and button moved to its own component.

Component was implemented in the profile/drafts draftcards both when editor is closed and open. 